### PR TITLE
added nose argumentsadded nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-coverage=1
+cover-package=service
+cover-erase=1
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Configure nosetests to enable coverage reporting via setup.cfg
